### PR TITLE
Implement EPIPE protection.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,0 @@
-require('coffee-script')
-module.exports = require('./index.coffee')

--- a/package.json
+++ b/package.json
@@ -6,18 +6,24 @@
     "type": "git",
     "url": "https://github.com/robskillington/replr"
   },
+  "main": "lib/index.js",
   "author": {
     "name": "Rob Skillington",
     "url": "http://github.com/robskillington"
   },
+  "scripts": {
+    "prepublish": "coffee --compile --output lib/ src/"
+  },
   "dependencies": {
     "async": "0.2.9",
-    "coffee-script": "1.6.3",
     "colors": "0.6.2",
     "doc": "0.0.3",
     "memorystream": "0.2.0",
     "merge": "1.1.2",
     "portscanner": "^1.0.0",
     "terminal": "0.1.4"
+  },
+  "devDependencies": {
+    "coffee-script": "1.6.3"
   }
 }

--- a/src/ReplrServer.coffee
+++ b/src/ReplrServer.coffee
@@ -100,6 +100,11 @@ class ReplrServer extends EventEmitter
     # Track client and remove when disconnect occurs
     client = new ReplrClient(@, @options, socket, r)
     @clients.push client
+    socket.on 'error', ()=>
+      if err && err.code == 'EPIPE'
+        return
+
+      throw err
     socket.on 'end', ()=>
       @clients.splice @clients.indexOf(client), 1
 

--- a/src/ReplrServer.coffee
+++ b/src/ReplrServer.coffee
@@ -100,7 +100,7 @@ class ReplrServer extends EventEmitter
     # Track client and remove when disconnect occurs
     client = new ReplrClient(@, @options, socket, r)
     @clients.push client
-    socket.on 'error', ()=>
+    socket.on 'error', (err)=>
       if err && err.code == 'EPIPE'
         return
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,6 @@
 repl = require('repl')
-ReplrServer = require('./src/ReplrServer')
-ReplrWorkerPassthrough = require('./src/ReplrWorkerPassthrough')
+ReplrServer = require('./ReplrServer')
+ReplrWorkerPassthrough = require('./ReplrWorkerPassthrough')
 
 # Expose simple REPL creation and worker REPL options
 funcs = 


### PR DESCRIPTION
- Add a TCP socket error listener to swallow EPIPE.
- Also add a prepublish step so that the coffeescript
  is compiled and only JS is published to npm.

cc @robskillington
