### PR TITLE
support port 0 properly

### DIFF
--- a/src/ReplrServer.coffee
+++ b/src/ReplrServer.coffee
@@ -96,7 +96,9 @@ class ReplrServer extends EventEmitter
 
       @socketServer.removeListener 'error', onError
 
-    if typeof @options.port == 'number'
+    if @options.port == 0
+      onVerified null, 'free'
+    else if typeof @options.port == 'number'
       portscanner.checkPortStatus @options.port, '127.0.0.1', onVerified
     else 
       onVerified null, 'free'


### PR DESCRIPTION
Using `portScanner` with port 0 has non deterministic behaviour across operating systems.

To work around a `portScanner` bug we just short circuit on port 0.
